### PR TITLE
fix(glab): use gitlab_project for version detection

### DIFF
--- a/catalog/glab.json
+++ b/catalog/glab.json
@@ -3,7 +3,7 @@
   "install_method": "github_release_binary",
   "description": "GitLab CLI tool bringing GitLab to your command line",
   "homepage": "https://gitlab.com/gitlab-org/cli",
-  "github_repo": "gitlab-org/cli",
+  "gitlab_project": "gitlab-org/cli",
   "binary_name": "glab",
   "download_url_template": "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/{version_nov}/glab_{version_nov}_linux_{arch}.tar.gz",
   "arch_map": {


### PR DESCRIPTION
## Summary

- Fix glab installation by using `gitlab_project` instead of `github_repo` for version detection
- The installer already supports GitLab API queries via `gitlab_project` field

## Problem

The glab CLI is hosted on GitLab, but the catalog entry used `github_repo: "gitlab-org/cli"`. This caused version detection to fail because the installer tried to get the latest release from GitHub.

## Solution

Replace `github_repo` with `gitlab_project` which triggers the existing GitLab API version detection logic in `github_release_binary.sh`.

## Test plan

- [x] Tested locally: Successfully installs glab v1.80.4
- [x] Verified version detection uses GitLab API