### PR TITLE
fix: align SKILL.md description with quality standard

### DIFF
--- a/skills/cli-tools/SKILL.md
+++ b/skills/cli-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-tools
-description: "Use when commands fail with 'command not found', installing missing CLI tools, auditing project environments, or batch-updating managed tools."
+description: "Use when commands fail with 'command not found', when installing missing CLI tools, when auditing project environments, or when batch-updating managed tools."
 ---
 
 # CLI Tools Skill


### PR DESCRIPTION
## Summary
- Fix SKILL.md description to use "Use when..." trigger format
- Remove "Agent Skill:" prefix and "By Netresearch." suffix

Addresses netresearch/claude-code-marketplace#32