### PR TITLE
chore: replace generic emails with GitHub references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
   "authors": [
     {
       "name": "Netresearch DTT GmbH",
-      "email": "info@netresearch.de",
       "homepage": "https://www.netresearch.de/",
       "role": "Manufacturer"
     }
@@ -16,5 +15,9 @@
   },
   "extra": {
     "ai-agent-skill": "SKILL.md"
+  },
+  "support": {
+    "issues": "https://github.com/netresearch/cli-tools-skill/issues",
+    "source": "https://github.com/netresearch/cli-tools-skill"
   }
 }


### PR DESCRIPTION
## Summary

- Replace generic `@netresearch.de` email addresses with GitHub-native references
- Add `support` section to package metadata with Issues/Source URLs

## Motivation

Generic email addresses in public repositories attract spam and create maintenance overhead. GitHub provides better mechanisms for each use case:
- **Support**: Issue tracker with templates and labels
- **Contact**: Discussions for general questions

## Test plan

- [ ] Verify package metadata is valid (composer validate)
- [ ] Verify links in documentation point to correct URLs