### PR TITLE
fix: standardize frontmatter and composer.json paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "netresearch/composer-agent-skill-plugin": "*"
   },
   "extra": {
-    "ai-agent-skill": "SKILL.md"
+    "ai-agent-skill": "skills/cli-tools/SKILL.md"
   },
   "support": {
     "issues": "https://github.com/netresearch/cli-tools-skill/issues",


### PR DESCRIPTION
## Summary
- Fix composer.json `extra.ai-agent-skill` path to point to actual SKILL.md location

## Context
The `extra.ai-agent-skill` path was pointing to `SKILL.md` at repo root, but the actual file is at `skills/cli-tools/SKILL.md`.