### PR TITLE
feat: add skill validation CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,3 +33,7 @@ jobs:
           severity: error
         env:
           SHELLCHECK_OPTS: -x
+
+  validate:
+    name: Skill Validation
+    uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main


### PR DESCRIPTION
## Summary
- Add skill validation job calling reusable workflow from skill-repo-skill
- Checks SKILL.md frontmatter, word count, composer.json, plugin.json, file presence

## Test plan
- [ ] CI passes with new validation job