### PR TITLE
feat: ship as npm package via @netresearch/agent-skill-coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ composer require netresearch/cli-tools-skill
 ```
 
 Requires [netresearch/composer-agent-skill-plugin](https://github.com/netresearch/composer-agent-skill-plugin).
+### npm (Node Projects)
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/cli-tools-skill
+```
+
+Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/node-agent-skill-coordinator), which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook. For pnpm, also allowlist the coordinator's postinstall:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
 ## Triggers
 
 The skill activates automatically on:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@netresearch/cli-tools-skill",
+  "version": "0.0.0-source",
+  "description": "Netresearch AI skill for CLI tool management, auto-installation and environment setup.",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",
+  "homepage": "https://github.com/netresearch/cli-tools-skill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netresearch/cli-tools-skill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/netresearch/cli-tools-skill/issues"
+  },
+  "keywords": [
+    "ai-agent-skill",
+    "cli-tools",
+    "ripgrep",
+    "fd",
+    "jq",
+    "command-not-found",
+    "anthropic",
+    "claude-code"
+  ],
+  "aiAgentSkill": "skills/cli-tools/SKILL.md",
+  "files": [
+    "skills/cli-tools/",
+    "hooks/",
+    "scripts/",
+    "LICENSE-MIT",
+    "LICENSE-CC-BY-SA-4.0",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "@netresearch/agent-skill-coordinator": "^0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "aiAgentSkill": "skills/cli-tools/SKILL.md",
   "files": [
     "skills/cli-tools/",
+    "catalog/",
     "hooks/",
     "scripts/",
     "LICENSE-MIT",


### PR DESCRIPTION
## Summary
- Adds `package.json` so the skill is npm-installable straight from this GitHub repo (no npm-registry publication required to start).
- README gains a parallel **npm (Node Projects)** section under Installation, mirroring the existing **Composer (PHP Projects)** section.

## How discovery works (consumer side)

```bash
npm install --save-dev \
  @netresearch/agent-skill-coordinator \
  github:netresearch/cli-tools-skill
```

After install, the coordinator's `postinstall` walks `node_modules`, finds this package via `aiAgentSkill: skills/cli-tools/SKILL.md`, validates the frontmatter, and writes a `<skills_system>` block into the project's `AGENTS.md`. Same shape as the Composer plugin's output.

## Why version stays at `0.0.0-source`

Versioning still lives in git tags and the existing Composer release workflow. A real npm version would be set at publish time; until then, `0.0.0-source` is the standard "this manifest exists for tooling, not as a release marker" placeholder.

## Sibling PRs (merged)
- https://github.com/netresearch/git-workflow-skill/pull/39
- https://github.com/netresearch/github-project-skill/pull/67
- https://github.com/netresearch/security-audit-skill/pull/67

Coordinator: https://github.com/netresearch/node-agent-skill-coordinator (`@netresearch/agent-skill-coordinator@0.1.2`)