### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tools",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "CLI tool management with automatic missing-tool detection, installation, and auditing",
   "repository": "https://github.com/netresearch/cli-tools-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/cli-tools/SKILL.md
+++ b/skills/cli-tools/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when ANY command fails with 'command not found', when installi
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires bash, common package managers."
 metadata:
-  version: "1.6.1"
+  version: "1.7.0"
   repository: "https://github.com/netresearch/cli-tools-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
## Release v1.7.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/cli-tools/SKILL.md` frontmatter `metadata.version` from `1.6.1` to `1.7.0`.

### Highlights since v1.6.1

- Ship the skill as an npm package via `@netresearch/agent-skill-coordinator`, with a follow-up fix to include the `catalog/` directory in the tarball (#28).
- Release workflow grants SLSA provenance permissions and drops the deprecated `workflow_dispatch.bump` input (#26, #27).
- CI plumbing: forward the `bump` input from `workflow_dispatch` to the reusable release workflow (#25).

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
