### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tools",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "CLI tool management with automatic missing-tool detection, installation, and auditing",
   "repository": "https://github.com/netresearch/cli-tools-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/cli-tools/SKILL.md
+++ b/skills/cli-tools/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when ANY command fails with 'command not found', when installi
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires bash, common package managers."
 metadata:
-  version: "1.7.0"
+  version: "1.8.0"
   repository: "https://github.com/netresearch/cli-tools-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Release **v1.8.0** (minor bump, conventional commits since v1.7.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.8.0.

Changes since v1.7.0:
- feat(catalog): add tokei and scc catalog entries
- 
- Both tools were already recommended in references/preferred-tools.md
- (as the fast replacement for cloc) and listed in SKILL.md's tool
- selection table, but had no catalog entry — so the install/audit
- workflow could not actually install them.
- 
- This closes that gap by adding:
- - catalog/tokei.json (cargo + brew)
- - catalog/scc.json (github_release_binary + go + brew)
- 
- Also bumps the cataloged-entries count in SKILL.md and README.md
- from 74 to 77 to match the current catalog/ directory.
- 
- Signed-off-by: Sebastian Mendel <github@sebastianmendel.de>
- fix(catalog): address review feedback on tokei/scc entries
- 
- - scc.json: use {arch} placeholder in asset_pattern so the arch_map is
-   actually applied for non-x86_64 hosts (gemini-code-assist).
- - scc.json: drop the "go" install method — the cli-tools-skill

After merge: a signed tag `v1.8.0` on `main` triggers the release workflow.