### PR TITLE
docs(troubleshooting): diagnose npm global prefix hijacked by a node shim

### DIFF
--- a/skills/cli-tools/references/troubleshooting.md
+++ b/skills/cli-tools/references/troubleshooting.md
@@ -26,6 +26,42 @@ When a tool installs but still shows "command not found":
    exec $SHELL             # Restart shell
    ```
 
+## Node/nvm: global installs land off-PATH (a `node` shim hijacks npm's prefix)
+
+When a global install succeeds (`npm i -g <tool>` reports "added N packages") but
+`command -v <tool>` then fails — or `npm prefix -g` points at a Node version that
+isn't your active/default one — suspect a **manual `node` symlink on PATH ahead of
+nvm** (commonly `~/.local/bin/node`, often created to give another tool a stable
+node).
+
+Because that shim is first on PATH, **every** `node`/`npm` resolves through it, so
+npm's global prefix is locked to that Node's tree — and globals (eslint, pnpm,
+prettier, …) land in a `bin/` that isn't on PATH. npm self-update can also hit the
+wrong tree.
+
+Diagnose:
+
+```bash
+command -v node                 # may show only the shim, e.g. ~/.local/bin/node
+node -p 'process.execPath'      # the REAL node the shim points at
+npm prefix -g                   # the prefix globals install into
+nvm version default             # what nvm thinks the default is
+```
+
+If `process.execPath` / `npm prefix -g` disagree with the nvm default, the shim is
+the cause.
+
+Fix — remove or re-point the shim identified above (the `node` on PATH that is
+**not** under `~/.nvm` — commonly `~/.local/bin/node`, but use the path your
+diagnosis returned), then align the nvm default:
+
+```bash
+SHIM=~/.local/bin/node          # <- replace with the shim path from the diagnosis
+rm "$SHIM"                      # or: ln -sf "$(nvm which default)" "$SHIM"
+nvm alias default node          # point default at the newest installed Node
+hash -r
+```
+
 ## Installation Blocked (Permission/System Restrictions)
 
 When system prevents normal installation, use these alternatives:


### PR DESCRIPTION
Adds a troubleshooting entry for a non-obvious failure: a manual `node` symlink ahead of nvm on PATH (e.g. `~/.local/bin/node`) hijacks npm's global prefix, so successful `npm i -g` installs land in a bin dir that isn't on PATH and `command -v` can't find them.

Covers symptoms, diagnosis (`node -p process.execPath` vs `npm prefix -g` vs `nvm version default`), and the fix (remove/re-point the shim + align the nvm default). Sourced from a real debugging session.