### PR TITLE
chore(release): v1.8.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tools",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "CLI tool management with automatic missing-tool detection, installation, and auditing",
   "repository": "https://github.com/netresearch/cli-tools-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/cli-tools/SKILL.md
+++ b/skills/cli-tools/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when ANY command fails with 'command not found', when installi
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires bash, common package managers."
 metadata:
-  version: "1.8.2"
+  version: "1.8.3"
   repository: "https://github.com/netresearch/cli-tools-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Prepare release v1.8.3 (patch: docs since v1.8.2). Version bump only: plugin.json + SKILL.md (2 files).