### PR TITLE
fix(ruff): ruff 0.16.0 compatibility

### DIFF
--- a/scripts/detect_missing_tool.py
+++ b/scripts/detect_missing_tool.py
@@ -4,9 +4,9 @@ Detect "command not found" errors in Bash tool output.
 Outputs a system reminder suggesting the cli-tools skill when a missing tool is detected.
 """
 
-import sys
-import re
 import json
+import re
+import sys
 
 # Patterns that indicate a missing command/tool
 MISSING_PATTERNS = [
@@ -40,7 +40,7 @@ def main():
     # Read tool output from stdin (Claude Code passes tool result)
     try:
         input_data = sys.stdin.read()
-    except Exception:
+    except Exception:  # noqa: BLE001 - hook must fail open on any stdin read error
         return
 
     if not input_data:


### PR DESCRIPTION
## Why
The reusable `validate.yml` Python-lint step now pins **ruff 0.16.0** (netresearch/skill-repo-skill#184). Under that pin, `ruff check .` fails on `scripts/detect_missing_tool.py` with findings the previously-unpinned ruff did not flag.

## Findings before (ruff@0.16.0 `check .`)
- `I001` scripts/detect_missing_tool.py:7 — import block un-sorted
- `BLE001` scripts/detect_missing_tool.py:43 — blind `except Exception`

(No `EXE001`/`FURB105` present. `format --check .` was already clean.)

## Fixes (behaviour-preserving)
- **I001**: reordered imports to `json`, `re`, `sys` (ruff safe autofix).
- **BLE001**: annotated the `except Exception:` on the stdin read with `# noqa: BLE001` and a reason. The handler intentionally **fails open** (`return`) so the detection hook never breaks the calling tool — narrowing the catch could let an error escape that must stay swallowed. Behaviour unchanged.

## Verify
- `uvx ruff@0.16.0 check .` -> All checks passed!
- `uvx ruff@0.16.0 format --check .` -> clean

Came from /retro follow-up on the reusable ruff pin (netresearch/skill-repo-skill#184).