### PR TITLE
fix(reconcile): map cargo binary to owning crate and probe post-reconcile binary

### DIFF
--- a/skills/cli-tools/scripts/lib/reconcile.sh
+++ b/skills/cli-tools/scripts/lib/reconcile.sh
@@ -44,8 +44,17 @@ remove_installation() {
       ;;
     cargo)
       if command -v cargo >/dev/null 2>&1; then
-        echo "[$tool] Uninstalling cargo package: $tool" >&2
-        cargo uninstall "$tool" 2>/dev/null || true
+        # cargo uninstall needs the crate name, which can differ from the
+        # binary (git-delta installs `delta`, watchexec-cli installs
+        # `watchexec`) — map binary → owning crate via `cargo install --list`.
+        local crate
+        crate="$(cargo install --list 2>/dev/null | awk -v bin="$binary" -v tool="$tool" '
+          /^[^[:space:]]/ { pkg = $1 }
+          /^[[:space:]]/  { if ($1 == bin || $1 == tool) { print pkg; exit } }')"
+        crate="${crate:-$tool}"
+        echo "[$tool] Uninstalling cargo package: $crate" >&2
+        cargo uninstall "$crate" 2>/dev/null \
+          || echo "[$tool] Warning: cargo uninstall $crate failed" >&2
       fi
       ;;
     npm)
@@ -297,6 +306,12 @@ reconcile_tool() {
 
   # Verify installation
   if command -v "$binary_name" >/dev/null 2>&1; then
+    # Presence is not function: a surviving wrapper script can depend on
+    # files the removed package owned (byobu's launcher sources
+    # /usr/lib/byobu), so probe that the binary actually runs.
+    if ! "$binary_name" --version >/dev/null 2>&1 && ! "$binary_name" version >/dev/null 2>&1; then
+      echo "[$tool] Warning: $binary_name is on PATH but does not run — the removal may have broken a wrapper that depended on the removed package" >&2
+    fi
     local new_method
     new_method="$(detect_install_method "$tool" "$binary_name")"
     echo "[$tool] ✓ Reconciliation complete: now installed via $new_method" >&2


### PR DESCRIPTION
## Problem

Field failures from `coding_agent_cli_toolset` reconcile runs (see netresearch/coding_agent_cli_toolset#134 / #135) exist identically in this skill's `scripts/lib/reconcile.sh`:

1. `cargo uninstall "$tool"` uses the binary name, but cargo needs the **crate** name — `git-delta` installs `delta`, `watchexec-cli` installs `watchexec` — and the `|| true` swallowed the failure silently, leaving the old install behind.
2. The post-reconcile verify only checks `command -v`. Presence is not function: a surviving wrapper script can depend on files the removed package owned (real incident: byobu's launcher script sourcing `/usr/lib/byobu`, broken by `apt remove byobu`).

## Fix

- Map binary → owning crate via `cargo install --list` (awk two-state parse; fallback to tool name), and warn on uninstall failure instead of hiding it.
- After reconciliation, probe `--version`/`version`; warn when the binary is on PATH but no longer runs.

Note: the other removal branches share the `|| true` silent-swallow pattern — candidate for a follow-up sweep.

## Test plan

- `bash -n` + shellcheck clean (only pre-existing SC1091 info).
- awk mapping verified against real `cargo install --list` format: `delta → git-delta`, `watchexec → watchexec-cli`, absent packages fall back to the tool name.

## Quality gate note

The `Smoke Test` check fails with `✗ github_release_binary.sh fd install failed:` (empty error). This failure is pre-existing on `main` — identical signature in [run 30123292238](https://github.com/netresearch/cli-tools-skill/actions/runs/30123292238) (2026-07-24, before this branch existed) — and the check is non-required (`mergeStateStatus: UNSTABLE`). This PR touches only `scripts/lib/reconcile.sh`; the failing path is the `github_release_binary.sh` installer. Tracked separately.
