### PR TITLE
fix(installers): stop silent death in GitHub release resolution and authenticate in CI

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,4 +16,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run smoke test
+        env:
+          # Installer release resolution: anonymous GitHub requests from
+          # shared runner IPs are rate-limited and made the round-trip flaky.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/smoke-test.sh

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -66,8 +66,11 @@ echo "=== smoke-test: full installer round-trip ==="
 # download -> binary in place) works, not just the catalog lookup in isolation.
 # PREFIX (read by lib/install_strategy.sh's get_install_dir) isolates the
 # install to a scratch dir instead of touching the real ~/.local/bin.
+# bash -x: the installer once died under `set -e` with ZERO output, making
+# the failure undiagnosable from CI logs. The xtrace lands in the install
+# log, which is only ever printed on failure — successes stay quiet.
 TMP_PREFIX="$(mktemp -d)"
-if PREFIX="$TMP_PREFIX" bash "$SCRIPTS/installers/github_release_binary.sh" fd >"$TMP_PREFIX/smoke-fd-install.log" 2>&1; then
+if PREFIX="$TMP_PREFIX" bash -x "$SCRIPTS/installers/github_release_binary.sh" fd >"$TMP_PREFIX/smoke-fd-install.log" 2>&1; then
   if [ -x "$TMP_PREFIX/bin/fd" ] && "$TMP_PREFIX/bin/fd" --version >/dev/null 2>&1; then
     pass "github_release_binary.sh installed a working fd: $("$TMP_PREFIX/bin/fd" --version)"
   else

--- a/skills/cli-tools/scripts/installers/github_release_binary.sh
+++ b/skills/cli-tools/scripts/installers/github_release_binary.sh
@@ -67,12 +67,24 @@ fi
 
 # Fallback to GitHub releases if no version URL
 if [ -z "$LATEST" ] && [ -n "$GITHUB_REPO" ]; then
-  LATEST="$(curl -fsSIL -H "User-Agent: cli-audit" -o /dev/null -w '%{url_effective}' \
-    "https://github.com/$GITHUB_REPO/releases/latest" 2>/dev/null | awk -F'/' '{print $NF}')"
+  # Authenticated API first when a token is available: anonymous requests
+  # from shared CI runner IPs are frequently rate-limited.
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    LATEST="$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" -H "User-Agent: cli-audit" \
+      "https://api.github.com/repos/$GITHUB_REPO/releases/latest" 2>/dev/null | \
+      jq -r '.tag_name // empty' 2>/dev/null || true)"
+  fi
+  # The `|| true` is load-bearing: under `set -eo pipefail` an unguarded
+  # failing curl inside this assignment kills the whole script with zero
+  # output (stderr is /dev/null'd) instead of reaching the error below.
+  if [ -z "$LATEST" ]; then
+    LATEST="$(curl -fsSIL -H "User-Agent: cli-audit" -o /dev/null -w '%{url_effective}' \
+      "https://github.com/$GITHUB_REPO/releases/latest" 2>/dev/null | awk -F'/' '{print $NF}' || true)"
+  fi
 fi
 
 if [ -z "$LATEST" ]; then
-  echo "[$TOOL] Error: Unable to resolve latest version" >&2
+  echo "[$TOOL] Error: Unable to resolve latest version (network failure or GitHub rate limit)" >&2
   echo "[$TOOL] before: ${before:-<none>}" >&2
   exit 1
 fi

--- a/skills/cli-tools/scripts/installers/github_release_binary.sh
+++ b/skills/cli-tools/scripts/installers/github_release_binary.sh
@@ -69,16 +69,16 @@ fi
 if [ -z "$LATEST" ] && [ -n "$GITHUB_REPO" ]; then
   # Authenticated API first when a token is available: anonymous requests
   # from shared CI runner IPs are frequently rate-limited.
-  if [ -n "${GITHUB_TOKEN:-}" ]; then
-    LATEST="$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" -H "User-Agent: cli-audit" \
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    LATEST="$(curl --proto '=https' -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" -H "User-Agent: cli-audit" \
       "https://api.github.com/repos/$GITHUB_REPO/releases/latest" 2>/dev/null | \
       jq -r '.tag_name // empty' 2>/dev/null || true)"
   fi
   # The `|| true` is load-bearing: under `set -eo pipefail` an unguarded
   # failing curl inside this assignment kills the whole script with zero
   # output (stderr is /dev/null'd) instead of reaching the error below.
-  if [ -z "$LATEST" ]; then
-    LATEST="$(curl -fsSIL -H "User-Agent: cli-audit" -o /dev/null -w '%{url_effective}' \
+  if [[ -z "$LATEST" ]]; then
+    LATEST="$(curl --proto '=https' -fsSIL -H "User-Agent: cli-audit" -o /dev/null -w '%{url_effective}' \
       "https://github.com/$GITHUB_REPO/releases/latest" 2>/dev/null | awk -F'/' '{print $NF}' || true)"
   fi
 fi

--- a/skills/cli-tools/scripts/installers/github_release_binary.sh
+++ b/skills/cli-tools/scripts/installers/github_release_binary.sh
@@ -253,15 +253,21 @@ if [ -n "$EXTRACT_DIR" ] && [ -d "$EXTRACT_DIR" ]; then
   rm -rf "$EXTRACT_DIR"
 fi
 
-# Report
-after="$(command -v "$BINARY_NAME" >/dev/null 2>&1 && \
-  (timeout 2 "$BINARY_NAME" --version </dev/null 2>/dev/null || \
-   timeout 2 "$BINARY_NAME" version --client </dev/null 2>/dev/null | head -1 || \
-   timeout 2 "$BINARY_NAME" version </dev/null 2>/dev/null | head -1 || true))"
-path="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
+# Report — probe the binary we actually installed, never a PATH lookup:
+# $BIN_DIR may not be on PATH (isolated PREFIX in CI), where the old
+# `command -v && (...)` substitution exited non-zero and set -e killed the
+# script silently right here; with multiple installs a PATH lookup can also
+# resolve a different copy than the one just written.
+installed_bin="$BIN_DIR/$BINARY_NAME"
+after=""
+if [[ -x "$installed_bin" ]]; then
+  after="$(timeout 2 "$installed_bin" --version </dev/null 2>/dev/null || \
+           timeout 2 "$installed_bin" version --client </dev/null 2>/dev/null | head -1 || \
+           timeout 2 "$installed_bin" version </dev/null 2>/dev/null | head -1 || true)"
+fi
 printf "[%s] before: %s\n" "$TOOL" "${before:-<none>}"
 printf "[%s] after:  %s\n" "$TOOL" "${after:-<none>}"
-if [ -n "$path" ]; then printf "[%s] path:   %s\n" "$TOOL" "$path"; fi
+printf "[%s] path:   %s\n" "$TOOL" "$installed_bin"
 
 # Refresh snapshot after successful installation
 refresh_snapshot "$TOOL" || true


### PR DESCRIPTION
## Problem

`Smoke Test` has failed on `main` since 2026-07-24 with `✗ github_release_binary.sh fd install failed:` and an **empty** log (#43).

Root cause, reproduced locally: the GitHub-releases fallback assigns `LATEST` from an unguarded `curl | awk` pipeline. Under `set -eo pipefail`, a failing curl inside the command substitution kills the whole script with zero output (stderr is already `/dev/null`'d) — it never reaches the 'Unable to resolve latest version' diagnostic. Anonymous requests from shared runner IPs are frequently rate-limited, which is why it fails in CI and passes locally. `fd.json` has neither `version_url` nor `gitlab_project`, so every fd install traverses this line. The sibling pipelines (lines 57, 64) already carry `|| true`; this one didn't.

## Fix

- Guard the pipeline with `|| true` so failures reach the proper error path (message now names rate limiting).
- Prefer the authenticated `api.github.com` lookup when `GITHUB_TOKEN` is set.
- Pass `GITHUB_TOKEN` to the smoke-test workflow step.

## Test plan

- Normal path: `PREFIX=tmp github_release_binary.sh fd` installs a working fd (verified: `fd 10.4.2`).
- Forced failure (curl shimmed to exit 22): exit 1 **with** `[fd] Error: Unable to resolve latest version (network failure or GitHub rate limit)` instead of an empty log.
- `bash -n` + shellcheck clean (pre-existing SC1091 info only).

Fixes #43