### PR TITLE
docs(troubleshooting): add no-root distro package extraction

### DIFF
--- a/skills/cli-tools/SKILL.md
+++ b/skills/cli-tools/SKILL.md
@@ -63,7 +63,7 @@ Run `scripts/check_environment.sh audit .` and `scripts/detect_project_type.sh`,
 | Symptom | Fix |
 |---------|-----|
 | Installed but not found | `hash -r` or add dir to PATH |
-| No sudo | `cargo install`, `pip install --user`, manual binary |
+| No sudo | `cargo install`, `pip install --user`, manual binary; on Debian/Ubuntu `apt-get download` + `dpkg -x` |
 | Debian `bat`=`batcat`, `fd`=`fdfind` | Symlink to `~/.local/bin/` |
 
 See `references/troubleshooting.md` for Docker fallbacks and permission workarounds.

--- a/skills/cli-tools/references/troubleshooting.md
+++ b/skills/cli-tools/references/troubleshooting.md
@@ -96,6 +96,37 @@ When system prevents normal installation, use these alternatives:
    cargo install <tool>  # Installs to ~/.cargo/bin
    ```
 
+5. **Extract the distro package (Debian/Ubuntu, no root):**
+
+   `apt-get download` needs no privileges — only `apt-get install` does. Fetch
+   the `.deb`, unpack it somewhere writable, and copy the binary onto PATH:
+
+   ```bash
+   cd "$(mktemp -d)"
+   apt-get download zstd brotli          # add every package you need
+   for d in *.deb; do dpkg -x "$d" ./root; done
+   mkdir -p ~/.local/bin
+   cp ./root/usr/bin/zstd ./root/usr/bin/brotli ~/.local/bin/
+   zstd --version && brotli --version    # confirm they run
+   ```
+
+   Reach for this **first** on Debian/Ubuntu when options 1-4 do not apply: it
+   is faster than compiling and gives the distro's own build, correctly linked
+   against the system's libraries.
+
+   It fits the case the other four miss — a C utility with no GitHub release
+   binary, no pip/npm/cargo package, and a compile that would pull a toolchain.
+   Verified on `zstd` and `brotli`, which a repo's pre-commit hook required
+   while `sudo` wanted a password.
+
+   Caveats: this does **not** resolve dependencies, so a package needing a
+   shared library the host lacks still fails at run time — that is why the
+   version check above is part of the recipe, not an afterthought. Add
+   `~/.local/bin` to PATH if it is not there already (see PATH Issues above).
+   For a library rather than a binary, extract it the same way and point
+   `LD_LIBRARY_PATH` at `./root/usr/lib/...`, but weigh that against a
+   container (option 1) — dozens of interdependent libraries get fragile fast.
+
 ## Batch Updaters That "Freeze"
 
 A batch update script that suppresses output (`cmd >/dev/null 2>&1`) but leaves


### PR DESCRIPTION
## Summary

Adds no-root extraction of a distro package (`apt-get download` + `dpkg -x`) as a fifth option under "Installation Blocked", for the case the existing four do not reach.

## Came from

`/retro` session on 2026-08-07: `3b2909e2-2cc1-4876-a6d4-76ec690cc48d`
Finding: B16 — hard-won technique worked out mid-session that a future agent would otherwise re-derive.

- **Symptom:** A repo's pre-commit hook required `zstd` and `brotli` to build assets. Neither was installed, `sudo` wanted a password, and the commit could not proceed. Nothing in the skill pointed at a way forward.
- **Cause:** The four documented alternatives assume the tool ships a release binary (option 2), is worth compiling (option 3), or exists as a pip/npm/cargo package (option 4). A plain C utility from the distro satisfies none of them, and the useful fact — that `apt-get download` needs no privileges, only `apt-get install` does — was not written down anywhere.
- **Required behavior:** On Debian/Ubuntu without root, download the `.deb`, unpack it with `dpkg -x`, copy the binary to `~/.local/bin`, and verify it runs before relying on it.
- **Verification:** No `evals/` in this repo. The recipe as written was executed in the session and unblocked the hook; both binaries ran.

## Change

- `references/troubleshooting.md` — new option 5 under "Installation Blocked (Permission/System Restrictions)", with the full command sequence, the instruction to prefer it over compiling on Debian/Ubuntu, the case it covers that the others miss, and its real failure mode: `dpkg -x` resolves no dependencies, which is why the version check is part of the recipe rather than an afterthought. Also notes when a container is the better answer (extracting a chain of interdependent libraries).
- `SKILL.md` — the "No sudo" quick-fix row now mentions the approach. Body goes from 413 to 420 words, within the 500-word cap.

## Test plan

- [ ] `SKILL.md` word count under 500 (420)
- [ ] The command sequence runs as written on a Debian/Ubuntu host without sudo
- [ ] `~/.local/bin` PATH guidance stays consistent with the existing "PATH Issues" section
