### PR TITLE
chore: release v1.9.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tools",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "CLI tool management with automatic missing-tool detection, installation, and auditing",
   "repository": "https://github.com/netresearch/cli-tools-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "cli-tools",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "CLI tool management with automatic missing-tool detection, installation, and auditing",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/cli-tools/SKILL.md
+++ b/skills/cli-tools/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when ANY command fails with 'command not found', when installi
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires bash, common package managers."
 metadata:
-  version: "1.9.0"
+  version: "1.9.1"
   repository: "https://github.com/netresearch/cli-tools-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Patch release. Delta since v1.9.0: widen @netresearch/agent-skill-coordinator to ^0.1 || ^0.2.0 (Renovate #52).